### PR TITLE
Merge `dev-task` into `dev`

### DIFF
--- a/src/utils/sw/task.h
+++ b/src/utils/sw/task.h
@@ -13,8 +13,8 @@ struct Yield {
   static inline void execute() { taskYIELD(); }
 };
 
-template<uint32_t ticks> struct Delay {
-  static inline void execute() { vTaskDelay(ticks); }
+template<uint32_t ms> struct Delay {
+  static inline void execute() { vTaskDelay(ms / portTICK_PERIOD_MS); }
 };
 
 } // namespace DELAYPOLICY


### PR DESCRIPTION
Changed the template parameter of `delaypolicies::Delay` to be the required delay in milliseconds instead of ticks. This is easier to work with in general (if necessary and beneficial the corresponding `DelayTicks` and `DelayMs` structs can be created).